### PR TITLE
Revert "Exclude WORKLOADS for GKE Cloud Logging"

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -116,7 +116,6 @@ module "gke" {
   ip_range_services                 = var.secondary_ip_range_services
   kubernetes_version                = var.kubernetes_version
   logging_service                   = var.logging_service
-  logging_enabled_components        = ["APISERVER", "CONTROLLER_MANAGER", "SCHEDULER", "SYSTEM_COMPONENTS"] # exclude "WORKLOADS"
   maintenance_exclusions            = var.maintenance_exclusions
   maintenance_start_time            = var.maintenance_window
   master_authorized_networks        = var.master_authorized_networks


### PR DESCRIPTION
Reverts streamnative/terraform-google-cloud#10

The variable is only in beta clusters submodule - have to revert 

https://github.com/search?q=repo%3Aterraform-google-modules%2Fterraform-google-kubernetes-engine%20logging_enabled_components&type=code