### PR TITLE
fix: handle empty suffix

### DIFF
--- a/cert_manager.tf
+++ b/cert_manager.tf
@@ -26,7 +26,7 @@ module "cert_manager_sa" {
   k8s_sa_name         = "cert-manager-controller"
   location            = var.region
   cluster_name        = module.gke.name
-  name                = format("cert-manager-%s", var.suffix)
+  name                = format("cert-manager%s", var.suffix != "" ? "-${var.suffix}" : "")
   namespace           = "kube-system"
   project_id          = var.project_id
   roles               = ["roles/dns.admin"]

--- a/external_dns.tf
+++ b/external_dns.tf
@@ -26,7 +26,7 @@ module "external_dns_sa" {
   k8s_sa_name         = "external-dns"
   location            = var.region
   cluster_name        = module.gke.name
-  name                = format("external-dns-%s", var.suffix)
+  name                = format("external-dns%s", var.suffix != "" ? "-${var.suffix}" : "")
   namespace           = "kube-system"
   project_id          = var.project_id
   roles               = ["roles/dns.admin"]

--- a/external_secrets.tf
+++ b/external_secrets.tf
@@ -26,7 +26,7 @@ module "external_secrets_sa" {
   k8s_sa_name         = "external-secrets"
   location            = var.region
   cluster_name        = module.gke.name
-  name                = format("external-secrets-%s", var.suffix)
+  name                = format("external-secrets%s", var.suffix != "" ? "-${var.suffix}" : "")
   namespace           = "kube-system"
   project_id          = var.project_id
   roles               = ["roles/secretmanager.secretAccessor"]

--- a/variables.tf
+++ b/variables.tf
@@ -487,7 +487,7 @@ variable "service_domain" {
 
 variable "suffix" {
   default     = ""
-  description = "A unique string that is used to distinguish cluster resources, where name legnth constraints are imposed by GKE. Defaults to an empty string."
+  description = "A unique string that is used to distinguish cluster resources, where name length constraints are imposed by GKE. Defaults to an empty string."
   type        = string
   validation {
     condition     = length(var.suffix) < 12


### PR DESCRIPTION
Fix #14 

### Motivation

```
GCP service account ids must be <= 30 chars matching regex ^[a-z](?:[-a-z0-9]{4,28}[a-z0-9])$
```

Refer https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/blob/e9a72cff0a8e7d35aaf84a7ca9d6788d02a864d4/modules/workload-identity/main.tf#L18