### PR TITLE
fix: upgrade default version of external-dns chart to 6.15.0

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -133,7 +133,7 @@ variable "external_dns_helm_chart_repository" {
 }
 
 variable "external_dns_helm_chart_version" {
-  default     = "6.1.8"
+  default     = "6.15.0"
   description = "Helm chart version for ExternalDNS. See https://github.com/bitnami/charts/tree/master/bitnami/external-dns for updates."
   type        = string
 }


### PR DESCRIPTION
Fix #13 

### Motivation
The bitnami/external-dns@6.1.8 has been removed in the helm repo.