### PR TITLE
fix: set versions range rather than exact

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -23,7 +23,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~>4.0"
+      version = "~> 4.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
@@ -31,11 +31,11 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "2.2.0"
+      version = "~> 2.2"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = ">=2.8.0"
+      version = "~> 2.8"
     }
   }
 }


### PR DESCRIPTION
### Motivation
As a root module, we should set a versions range rather than exact version, as it will block module consumer to upgrade.

Refer to this [best practice of version constraints](https://developer.hashicorp.com/terraform/language/expressions/version-constraints#best-practices).