### PR TITLE
allow global access for internal loadbalancer

### DIFF
--- a/istio.tf
+++ b/istio.tf
@@ -17,6 +17,7 @@ locals {
     internet_facing = null,
     internal_only = {
       "networking.gke.io/load-balancer-type" = "Internal"
+      "networking.gke.io/internal-load-balancer-allow-global-access": "true"
     }
   }
 }


### PR DESCRIPTION
see https://cloud.google.com/kubernetes-engine/docs/how-to/internal-load-balancing#global_access, that's required for cross region access even in same shared VPC 