### PR TITLE
fix: Revert "feat: Enable VPA (#35)"

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -148,7 +148,6 @@ module "gke" {
   remove_default_node_pool          = true
   release_channel                   = var.release_channel
   subnetwork                        = var.vpc_subnet
-  enable_vertical_pod_autoscaling   = true
 }
 
 module "gke_private" {


### PR DESCRIPTION
This reverts commit 4366446a21f3c0fbb17f72c4967e46be30b2e0ec.

It seems more safe to install vpa in the bootstrap1 step