### PR TITLE
fix: Add KMS IAM binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ tf apply
 | [kubernetes_storage_class.sn_default](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/storage_class) | resource |
 | [kubernetes_storage_class.sn_ssd](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/storage_class) | resource |
 | [google_compute_zones.available](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_zones) | data source |
+| [google_project.number](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |
 
 ## Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ data "google_compute_zones" "available" {
 
 # Declared to infer the project number
 data "google_project" "project" {
-  project = var.project_id
+  project_id = var.project_id
 }
 
 resource "google_kms_key_ring" "keyring" {


### PR DESCRIPTION
- Related to https://github.com/streamnative/terraform-google-cloud/pull/42
- **Added required kms_iam_binding for gke encryption**
- **Added docs**

Even though we specify a new service account, we need to grant this one access to KMS.

>Note: For [CMEK-protected node boot disks](https://cloud.google.com/kubernetes-engine/docs/how-to/using-cmek#update_a_cluster_with_cmek-protected_node_boot_disks) and [CMEK-protected attached disks](https://cloud.google.com/kubernetes-engine/docs/how-to/using-cmek#create_a_cmek_protected_attached_disk), this Compute Engine service account is the account which requires permissions to do encryption using your Cloud KMS key. This is true even if you are using a custom service account on your nodes.

https://cloud.google.com/kubernetes-engine/docs/how-to/using-cmek

