### PR TITLE
feat: Support private nodes on public GKE

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -158,7 +158,7 @@ module "gke" {
   count   = var.enable_private_gke ? 0 : 1
   source  = "terraform-google-modules/kubernetes-engine/google"
   name    = var.cluster_name
-  version = "29.0.0"
+  version = "32.0.4"
 
   add_cluster_firewall_rules        = var.add_cluster_firewall_rules
   add_master_webhook_firewall_rules = var.add_master_webhook_firewall_rules

--- a/main.tf
+++ b/main.tf
@@ -46,44 +46,48 @@ locals {
 
   ### Node Pools
   default_node_pool_config = {
-    auto_repair        = var.node_pool_auto_repair
-    auto_upgrade       = var.node_pool_auto_upgrade
-    autoscaling        = var.node_pool_autoscaling
-    disk_size_gb       = var.node_pool_disk_size
-    disk_type          = var.node_pool_disk_type
-    enable_secure_boot = var.node_pool_secure_boot
-    image_type         = var.node_pool_image_type
-    initial_node_count = var.node_pool_autoscaling_initial_count
-    local_ssd_count    = var.node_pool_ssd_count
-    machine_type       = var.node_pool_machine_type
-    max_pods_per_node  = var.node_pool_max_pods_per_node
-    max_count          = var.node_pool_autoscaling_max_size
-    min_count          = var.node_pool_autoscaling_min_size
-    name               = var.node_pool_name
-    node_count         = var.node_pool_autoscaling ? null : var.node_pool_count
-    node_locations     = var.node_pool_locations != "" ? var.node_pool_locations : ""
-    service_account    = var.create_service_account ? "" : var.node_pool_service_account
-    version            = var.node_pool_auto_upgrade ? null : var.node_pool_version
+    auto_repair          = var.node_pool_auto_repair
+    auto_upgrade         = var.node_pool_auto_upgrade
+    autoscaling          = var.node_pool_autoscaling
+    disk_size_gb         = var.node_pool_disk_size
+    disk_type            = var.node_pool_disk_type
+    enable_secure_boot   = var.node_pool_secure_boot
+    image_type           = var.node_pool_image_type
+    initial_node_count   = var.node_pool_autoscaling_initial_count
+    local_ssd_count      = var.node_pool_ssd_count
+    machine_type         = var.node_pool_machine_type
+    pod_range            = var.secondary_ip_range_pods
+    enable_private_nodes = var.enable_private_nodes
+    max_pods_per_node    = var.node_pool_max_pods_per_node
+    max_count            = var.node_pool_autoscaling_max_size
+    min_count            = var.node_pool_autoscaling_min_size
+    name                 = var.node_pool_name
+    node_count           = var.node_pool_autoscaling ? null : var.node_pool_count
+    node_locations       = var.node_pool_locations != "" ? var.node_pool_locations : ""
+    service_account      = var.create_service_account ? "" : var.node_pool_service_account
+    version              = var.node_pool_auto_upgrade ? null : var.node_pool_version
   }
   func_pool_config = {
-    auto_repair        = var.func_pool_auto_repair
-    auto_upgrade       = var.func_pool_auto_upgrade
-    autoscaling        = var.func_pool_autoscaling
-    disk_size_gb       = var.func_pool_disk_size
-    disk_type          = var.func_pool_disk_type
-    enable_secure_boot = var.node_pool_secure_boot
-    image_type         = var.func_pool_image_type
-    initial_node_count = var.func_pool_autoscaling_initial_count
-    local_ssd_count    = var.func_pool_ssd_count
-    machine_type       = var.func_pool_machine_type
-    max_pods_per_node  = var.func_pool_max_pods_per_node
-    max_count          = var.func_pool_autoscaling_max_size
-    min_count          = var.func_pool_autoscaling_min_size
-    name               = var.func_pool_name
-    node_count         = var.func_pool_autoscaling ? null : var.func_pool_count
-    node_locations     = var.func_pool_locations != "" ? var.func_pool_locations : var.node_pool_locations
-    service_account    = var.create_service_account ? "" : var.func_pool_service_account
-    version            = var.func_pool_auto_upgrade ? null : var.func_pool_version
+    auto_repair          = var.func_pool_auto_repair
+    auto_upgrade         = var.func_pool_auto_upgrade
+    autoscaling          = var.func_pool_autoscaling
+    disk_size_gb         = var.func_pool_disk_size
+    disk_type            = var.func_pool_disk_type
+    enable_secure_boot   = var.node_pool_secure_boot
+    image_type           = var.func_pool_image_type
+    initial_node_count   = var.func_pool_autoscaling_initial_count
+    local_ssd_count      = var.func_pool_ssd_count
+    machine_type         = var.func_pool_machine_type
+    pod_range            = var.secondary_ip_range_pods
+    enable_private_nodes = var.enable_private_nodes
+    max_pods_per_node    = var.func_pool_max_pods_per_node
+    max_count            = var.func_pool_autoscaling_max_size
+    min_count            = var.func_pool_autoscaling_min_size
+    name                 = var.func_pool_name
+    node_count           = var.func_pool_autoscaling ? null : var.func_pool_count
+    node_locations       = var.func_pool_locations != "" ? var.func_pool_locations : var.node_pool_locations
+    service_account      = var.create_service_account ? "" : var.func_pool_service_account
+    version              = var.func_pool_auto_upgrade ? null : var.func_pool_version
   }
   default_node_pool = merge(
     local.default_node_pool_config,
@@ -158,7 +162,7 @@ module "gke" {
   count   = var.enable_private_gke ? 0 : 1
   source  = "terraform-google-modules/kubernetes-engine/google"
   name    = var.cluster_name
-  version = "29.0.0"
+  version = "30.3.0"
 
   add_cluster_firewall_rules        = var.add_cluster_firewall_rules
   add_master_webhook_firewall_rules = var.add_master_webhook_firewall_rules
@@ -200,7 +204,7 @@ module "gke_private" {
   source = "terraform-google-modules/kubernetes-engine/google//modules/private-cluster"
 
   name    = var.cluster_name
-  version = "29.0.0"
+  version = "30.3.0"
 
   add_cluster_firewall_rules        = var.add_cluster_firewall_rules
   add_master_webhook_firewall_rules = var.add_master_webhook_firewall_rules

--- a/main.tf
+++ b/main.tf
@@ -87,14 +87,14 @@ locals {
   }
   default_node_pool = merge(
     local.default_node_pool_config,
-    var.enable_private_gke ?
+    !var.enable_private_gke ?
     {
       enable_private_nodes = var.enable_private_nodes
     } : {}
   )
   func_pool = merge(
     local.func_pool_config,
-    var.enable_private_gke ?
+    !var.enable_private_gke ?
     {
       enable_private_nodes = var.enable_private_nodes
     } : {}
@@ -158,7 +158,7 @@ module "gke" {
   count   = var.enable_private_gke ? 0 : 1
   source  = "terraform-google-modules/kubernetes-engine/google"
   name    = var.cluster_name
-  version = "32.0.4"
+  version = "29.0.0"
 
   add_cluster_firewall_rules        = var.add_cluster_firewall_rules
   add_master_webhook_firewall_rules = var.add_master_webhook_firewall_rules

--- a/variables.tf
+++ b/variables.tf
@@ -645,7 +645,7 @@ variable "istio_network_loadbalancer" {
 variable "enable_private_nodes" {
   type        = bool
   description = "Whether nodes have internal IP addresses only, only used for private clusters"
-  default     = true
+  default     = false
 }
 
 variable "master_ipv4_cidr_block" {

--- a/variables.tf
+++ b/variables.tf
@@ -69,25 +69,27 @@ variable "cert_issuer_support_email" {
 
 variable "cluster_autoscaling_config" {
   default = {
-    enabled       = false
-    max_cpu_cores = null
-    min_cpu_cores = null
-    max_memory_gb = null
-    min_memory_gb = null
-    gpu_resources = []
-    auto_repair   = true
-    auto_upgrade  = false
+    enabled             = false
+    max_cpu_cores       = null
+    min_cpu_cores       = null
+    max_memory_gb       = null
+    min_memory_gb       = null
+    gpu_resources       = []
+    auto_repair         = true
+    auto_upgrade        = false
+    autoscaling_profile = "BALANCED"
   }
   description = "Cluster autoscaling configuration for node auto-provisioning. This is disabled for our configuration, since we typically want to scale existing node pools rather than add new ones to the cluster"
   type = object({
-    enabled       = bool
-    min_cpu_cores = number
-    max_cpu_cores = number
-    min_memory_gb = number
-    max_memory_gb = number
-    gpu_resources = list(object({ resource_type = string, minimum = number, maximum = number }))
-    auto_repair   = bool
-    auto_upgrade  = bool
+    enabled             = bool
+    min_cpu_cores       = number
+    max_cpu_cores       = number
+    min_memory_gb       = number
+    max_memory_gb       = number
+    gpu_resources       = list(object({ resource_type = string, minimum = number, maximum = number }))
+    auto_repair         = bool
+    auto_upgrade        = bool
+    autoscaling_profile = string
   })
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -644,7 +644,7 @@ variable "istio_network_loadbalancer" {
 
 variable "enable_private_nodes" {
   type        = bool
-  description = "Whether nodes have internal IP addresses only, only used for private clusters"
+  description = "Whether nodes have internal IP addresses only."
   default     = false
 }
 


### PR DESCRIPTION
- upgrade GKE module to 30.3.0
  - Specify autoscaling_profile in cluster_autoscaling_config
- Specify `pod_range` in node_pools by default, it's a limitation in upstream module, otherwise `enable_private_nodes` won't take effect
  
https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/blob/50c1a420179df3a7c596c93f8ecc05a207276aa1/cluster.tf#L478-L484