### PR TITLE
fix: Unset gcp_public_cidrs_access_enabled in default case

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -182,7 +182,7 @@ module "gke" {
   maintenance_exclusions            = var.maintenance_exclusions
   maintenance_start_time            = var.maintenance_window
   master_authorized_networks        = var.master_authorized_networks
-  gcp_public_cidrs_access_enabled   = var.gcp_public_cidrs_access_enabled
+  gcp_public_cidrs_access_enabled   = length(var.master_authorized_networks) > 0 ? var.gcp_public_cidrs_access_enabled : null
   network                           = var.vpc_network
   network_project_id                = var.network_project_id
   network_policy                    = var.cluster_network_policy


### PR DESCRIPTION
unset `gcp_public_cidrs_access_enabled` when `master_authorized_networks` not configured, otherwise `master_authorized_networks_config` will be set as an empty list in upstream module, which will unexpectedly prevent access to the GKE public endpoint.


https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/blob/745b16ac02faf106cca502dd77e0499651a9f5b4/cluster.tf#L192-L204