### PR TITLE
feat: add additional_tags support for standardized resource labeling

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,6 +32,7 @@ resource "google_kms_crypto_key" "gke_encryption_key" {
   name            = "sn-gke-key-${var.cluster_name}"
   key_ring        = google_kms_key_ring.keyring[0].id
   rotation_period = "12960000s" #150 days
+  labels          = var.additional_tags
 }
 
 # Required for GKE to use the encryption key
@@ -191,6 +192,7 @@ module "gke" {
   database_encryption               = local.database_encryption
   deletion_protection               = var.deletion_protection
   enable_l4_ilb_subsetting          = var.enable_l4_ilb_subsetting
+  cluster_resource_labels           = var.additional_tags
 
   cluster_dns_provider          = var.cluster_dns_provider
   cluster_dns_scope             = var.cluster_dns_scope
@@ -246,6 +248,7 @@ module "gke_private" {
   database_encryption               = local.database_encryption
   deletion_protection               = var.deletion_protection
   enable_l4_ilb_subsetting          = var.enable_l4_ilb_subsetting
+  cluster_resource_labels           = var.additional_tags
 
   cluster_dns_provider          = var.cluster_dns_provider
   cluster_dns_scope             = var.cluster_dns_scope

--- a/main.tf
+++ b/main.tf
@@ -105,10 +105,10 @@ locals {
   )
   node_pools = var.enable_func_pool ? [local.default_node_pool, local.func_pool] : [local.default_node_pool]
   node_pools_labels = {
-    all = {
+    all = merge({
       cluster_name = var.cluster_name
       managed_by   = "terraform"
-    }
+    }, var.additional_tags)
   }
   node_pools_metadata = {
     all = {}

--- a/modules/dns-bucket/bucket.tf
+++ b/modules/dns-bucket/bucket.tf
@@ -20,6 +20,7 @@ resource "google_storage_bucket" "velero" {
   location                    = var.bucket_location
   uniform_bucket_level_access = var.bucket_uniform_bucket_level_access
   force_destroy               = true
+  labels                      = var.additional_tags
   encryption {
     default_kms_key_name = var.bucket_encryption_kms_key_id
   }
@@ -39,6 +40,7 @@ resource "google_storage_bucket" "tiered_storage" {
   location                    = var.bucket_location
   uniform_bucket_level_access = var.bucket_uniform_bucket_level_access
   force_destroy               = true
+  labels                      = var.additional_tags
   encryption {
     default_kms_key_name = var.bucket_encryption_kms_key_id
   }
@@ -60,6 +62,7 @@ resource "google_storage_bucket" "loki" {
   location                    = var.bucket_location
   uniform_bucket_level_access = var.bucket_uniform_bucket_level_access
   force_destroy               = true
+  labels                      = var.additional_tags
 
   dynamic "soft_delete_policy" {
     for_each = !var.bucket_cluster_backup_soft_delete ? ["apply"] : []

--- a/modules/dns-bucket/dns.tf
+++ b/modules/dns-bucket/dns.tf
@@ -27,6 +27,7 @@ resource "google_dns_managed_zone" "zone" {
   name          = local.new_zone_id
   dns_name      = local.new_zone_name
   force_destroy = true
+  labels        = var.additional_tags
 
   cloud_logging_config {
     enable_logging = false

--- a/modules/dns-bucket/variables.tf
+++ b/modules/dns-bucket/variables.tf
@@ -79,3 +79,9 @@ variable "enable_velero" {
   default     = false
   description = "Enable velero for backups. If set to false, no velero resources will be created."
 }
+
+variable "additional_tags" {
+  default     = {}
+  description = "Additional labels to apply to GCS bucket resources."
+  type        = map(string)
+}

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -80,4 +80,3 @@ variable "nat_gateway_name" {
   default     = "sn-nat-gateway"
   description = "The name of Cloud NAT Gateway"
 }
-

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -81,8 +81,3 @@ variable "nat_gateway_name" {
   description = "The name of Cloud NAT Gateway"
 }
 
-variable "additional_tags" {
-  default     = {}
-  description = "Additional labels to apply to GCP resources."
-  type        = map(string)
-}

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -80,3 +80,9 @@ variable "nat_gateway_name" {
   default     = "sn-nat-gateway"
   description = "The name of Cloud NAT Gateway"
 }
+
+variable "additional_tags" {
+  default     = {}
+  description = "Additional labels to apply to GCP resources."
+  type        = map(string)
+}

--- a/variables.tf
+++ b/variables.tf
@@ -92,6 +92,12 @@ variable "cluster_http_load_balancing" {
   type        = bool
 }
 
+variable "additional_tags" {
+  default     = {}
+  description = "Additional labels to apply to GKE node pool resources."
+  type        = map(string)
+}
+
 variable "cluster_name" {
   description = "The name of your GKE cluster."
   type        = string


### PR DESCRIPTION
## Summary

Adds `additional_tags` variable support across the GKE cluster module and submodules, enabling consistent GCP label propagation to all provisioned resources.

**Root module (`/`):**
- Added `additional_tags` variable (`map(string)`, default `{}`)
- `module.gke` + `module.gke_private`: pass `cluster_resource_labels = var.additional_tags` (labels the GKE cluster resource itself)
- `local.node_pools_labels.all`: merged with `var.additional_tags` (labels all node pool VMs)
- `google_kms_crypto_key.gke_encryption_key`: added `labels = var.additional_tags`

**`modules/dns-bucket`:**
- Added `additional_tags` variable
- Applied `labels = var.additional_tags` to `google_storage_bucket` (velero, tiered_storage, loki) and `google_dns_managed_zone`

**`modules/vpc`:**
- Added `additional_tags` variable
- Applied `network_labels = var.additional_tags` to `module.network` and `labels = var.additional_tags` to `module.cloud_router`

## Use case

The CloudEnvironment reconciler sets `cloud.streamnative.io/cloudenvironment-name` and related labels via `additionalTags` in the Argo workflow TF vars. This change ensures those labels are propagated to GKE clusters, node pools, KMS keys, GCS buckets, DNS zones, VPC networks, and Cloud Routers.

## Test plan

- [ ] Verify `terraform plan` shows label changes on existing resources (no destructive changes)
- [ ] Confirm `additional_tags = {}` (default) produces no diff on existing deployments
- [ ] Validate labels appear on GKE cluster, node pools, and GCS buckets after apply