### PR TITLE
feat: Force labels to lower

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -193,7 +193,7 @@ module "gke" {
   database_encryption               = local.database_encryption
   deletion_protection               = var.deletion_protection
   enable_l4_ilb_subsetting          = var.enable_l4_ilb_subsetting
-  cluster_resource_labels           = var.additional_tags
+  cluster_resource_labels           = { for k, v in var.additional_tags : lower(k) => lower(v) }
 
   cluster_dns_provider          = var.cluster_dns_provider
   cluster_dns_scope             = var.cluster_dns_scope

--- a/modules/dns-bucket/bucket.tf
+++ b/modules/dns-bucket/bucket.tf
@@ -20,7 +20,7 @@ resource "google_storage_bucket" "velero" {
   location                    = var.bucket_location
   uniform_bucket_level_access = var.bucket_uniform_bucket_level_access
   force_destroy               = true
-  labels                      = var.additional_tags
+  labels                      = { for k, v in var.additional_tags : k => lower(v) }
   encryption {
     default_kms_key_name = var.bucket_encryption_kms_key_id
   }
@@ -40,7 +40,7 @@ resource "google_storage_bucket" "tiered_storage" {
   location                    = var.bucket_location
   uniform_bucket_level_access = var.bucket_uniform_bucket_level_access
   force_destroy               = true
-  labels                      = var.additional_tags
+  labels                      = { for k, v in var.additional_tags : k => lower(v) }
   encryption {
     default_kms_key_name = var.bucket_encryption_kms_key_id
   }
@@ -62,7 +62,7 @@ resource "google_storage_bucket" "loki" {
   location                    = var.bucket_location
   uniform_bucket_level_access = var.bucket_uniform_bucket_level_access
   force_destroy               = true
-  labels                      = var.additional_tags
+  labels                      = { for k, v in var.additional_tags : k => lower(v) }
 
   dynamic "soft_delete_policy" {
     for_each = !var.bucket_cluster_backup_soft_delete ? ["apply"] : []

--- a/modules/dns-bucket/bucket.tf
+++ b/modules/dns-bucket/bucket.tf
@@ -20,7 +20,7 @@ resource "google_storage_bucket" "velero" {
   location                    = var.bucket_location
   uniform_bucket_level_access = var.bucket_uniform_bucket_level_access
   force_destroy               = true
-  labels                      = { for k, v in var.additional_tags : k => lower(v) }
+  labels                      = { for k, v in var.additional_tags : lower(k) => lower(v) }
   encryption {
     default_kms_key_name = var.bucket_encryption_kms_key_id
   }
@@ -40,7 +40,7 @@ resource "google_storage_bucket" "tiered_storage" {
   location                    = var.bucket_location
   uniform_bucket_level_access = var.bucket_uniform_bucket_level_access
   force_destroy               = true
-  labels                      = { for k, v in var.additional_tags : k => lower(v) }
+  labels                      = { for k, v in var.additional_tags : lower(k) => lower(v) }
   encryption {
     default_kms_key_name = var.bucket_encryption_kms_key_id
   }
@@ -62,7 +62,7 @@ resource "google_storage_bucket" "loki" {
   location                    = var.bucket_location
   uniform_bucket_level_access = var.bucket_uniform_bucket_level_access
   force_destroy               = true
-  labels                      = { for k, v in var.additional_tags : k => lower(v) }
+  labels                      = { for k, v in var.additional_tags : lower(k) => lower(v) }
 
   dynamic "soft_delete_policy" {
     for_each = !var.bucket_cluster_backup_soft_delete ? ["apply"] : []

--- a/modules/dns-bucket/dns.tf
+++ b/modules/dns-bucket/dns.tf
@@ -27,7 +27,7 @@ resource "google_dns_managed_zone" "zone" {
   name          = local.new_zone_id
   dns_name      = local.new_zone_name
   force_destroy = true
-  labels        = var.additional_tags
+  labels        = { for k, v in var.additional_tags : lower(k) => lower(v) }
 
   cloud_logging_config {
     enable_logging = false


### PR DESCRIPTION
## Summary

GCP labels require lowercase keys and values. Previously `var.additional_tags` was passed directly to label fields, which would cause a `400 Bad Request` from the GCP API if any key or value contained uppercase characters.

This change normalizes all label keys and values to lowercase using a `for` expression across:
- `google_storage_bucket.velero` (dns-bucket module)
- `google_storage_bucket.tiered_storage` (dns-bucket module)
- `google_storage_bucket.loki` (dns-bucket module)
- `google_dns_managed_zone.zone` (dns-bucket module)
- `module.gke` cluster resource labels (main.tf)

If `additional_tags` is empty (`{}`), the expression evaluates to `{}` and no labels are applied.

## Test plan
- [ ] Apply with uppercase tags and verify GCP accepts them
- [ ] Apply with empty `additional_tags` and verify no labels error